### PR TITLE
Change implementation to run native Android Code

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -6,6 +6,8 @@
 
     <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="22" />
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"

--- a/android/src/com/mygdx/game/android/ActionResolverAndroid.java
+++ b/android/src/com/mygdx/game/android/ActionResolverAndroid.java
@@ -21,16 +21,14 @@ public class ActionResolverAndroid implements ActionResolver {
         handler.post(new Runnable() {
             @Override
             public void run() {
-                int a;
                 ConnectivityManager connManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
                 NetworkInfo mWifi = connManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
 
                 if (mWifi.isConnected()) {
-                    a=1;
-                }else{
-                    a=0;
+                    Toast.makeText(context, "There is network connection!", Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(context, "No network connection!", Toast.LENGTH_SHORT).show();
                 }
-                Toast.makeText(context, "No network connection!", Toast.LENGTH_SHORT).show();
 
 
             }

--- a/android/src/com/mygdx/game/android/AndroidLauncher.java
+++ b/android/src/com/mygdx/game/android/AndroidLauncher.java
@@ -15,6 +15,5 @@ public class AndroidLauncher extends AndroidApplication {
         actionResolverAndroid = new ActionResolverAndroid(this);
 		AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
         initialize(new MyGdxGame(actionResolverAndroid), config);
-		//initialize(new MyGdxGame(), config);
 	}
 }

--- a/core/src/com/mygdx/game/MyGdxGame.java
+++ b/core/src/com/mygdx/game/MyGdxGame.java
@@ -1,12 +1,9 @@
 package com.mygdx.game;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Screen;
-import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.Game;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 
-public class MyGdxGame implements Screen {
+public class MyGdxGame extends Game {
 
     ActionResolver actionResolver;
 
@@ -15,47 +12,21 @@ public class MyGdxGame implements Screen {
     }
 
 	SpriteBatch batch;
-	Texture img;
-
-	@Override
-	public void render (float delta) {
-		Gdx.gl.glClearColor(1, 0, 0, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		batch.begin();
-		batch.draw(img, 0, 0);
-		batch.end();
-	}
 
     @Override
-    public void resize(int width, int height) {
-    }
-
-    @Override
-    public void show() {
-        int a;
+    public void create() {
         batch = new SpriteBatch();
-        img = new Texture("badlogic.jpg");
-
-        actionResolver.getNetInfo();
-
+        this.setScreen(new MyScreen(this));
     }
 
     @Override
-    public void hide() {
-
-    }
-
-    @Override
-    public void pause() {
-    }
-
-    @Override
-    public void resume() {
+    public void render() {
+        super.render();
     }
 
     @Override
     public void dispose() {
-
+        batch.dispose();
     }
 
 }

--- a/core/src/com/mygdx/game/MyScreen.java
+++ b/core/src/com/mygdx/game/MyScreen.java
@@ -1,0 +1,50 @@
+package com.mygdx.game;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.GL20;
+
+public class MyScreen implements Screen {
+
+    MyGdxGame game;
+
+    public MyScreen(final MyGdxGame game) {
+        this.game = game;
+    }
+
+    @Override
+    public void resize(int width, int height) {
+
+    }
+
+    @Override
+    public void resume() {
+
+    }
+
+    @Override
+    public void pause() {
+
+    }
+
+    @Override
+    public void hide() {
+
+    }
+
+    @Override
+    public void show() {
+        game.actionResolver.getNetInfo();
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0, 0);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+}


### PR DESCRIPTION
Resolves problematic code saying initialize(new
MyGdxGame(actionResolverAndroid), config); .... cannot be applied
By introducing a Game class and a Screen which shows a Toast.
This example was made taking as reference the following tutorial:

https://carlorodriguez.github.io/blog/2014/10/05/android-platform-specific-code-with-libgdx/